### PR TITLE
update dependencies && bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-literal"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["kgv <kgv@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 description = "Crypto literal procedural macros."
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.2.1"
-crypto-literal-algorithm = "0.1.1"
-crypto-literal-macro = "0.1.1"
+crypto-literal-algorithm = { path = "./algorithm/"}
+crypto-literal-macro = { path = "./macro/" }
 derive_more = "0.99.5"
 serde = "1.0.105"
 

--- a/algorithm/Cargo.toml
+++ b/algorithm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-literal-algorithm"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["kgv <kgv@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 description = "Crypto literal procedural macros algorithm."
@@ -10,5 +10,5 @@ repository = "https://github.com/kgv/crypto-literal"
 edition = "2018"
 
 [dependencies]
-aes = "0.3.2"
-ofb = "0.1.1"
+aes = "0.8.4"
+ofb = "0.6.1"

--- a/algorithm/src/lib.rs
+++ b/algorithm/src/lib.rs
@@ -1,8 +1,5 @@
-use aes::Aes256;
-use ofb::{
-    stream_cipher::{NewStreamCipher, SyncStreamCipher},
-    Ofb,
-};
+use aes::{cipher::{StreamCipher, KeyIvInit}, Aes256};
+use ofb::Ofb;
 
 /// Crypto algorithm.
 #[derive(Debug, PartialEq, Eq)]
@@ -37,7 +34,7 @@ pub struct Aes {
 impl Aes {
     #[inline(always)]
     pub fn encrypt(buffer: &mut [u8], iv: &[u8], key: &[u8]) {
-        let mut cipher = Ofb::<Aes256>::new_var(key, iv).expect("create cipher (Ofb<Aes256>)");
+        let mut cipher = Ofb::<Aes256>::new(key.into(), iv.into());
         cipher.apply_keystream(buffer);
     }
 

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,10 +1,3 @@
-#![feature(custom_inner_attributes)]
-#![feature(proc_macro_hygiene)]
-// #![crypto_literal::algorithm(none)]
-// #![crypto_literal::algorithm(xor)]
-#![crypto_literal::algorithm(aes)]
-#![crypto_literal::key("0123456789")]
-
 use anyhow::Result;
 use crypto_literal::{encrypt, CryptoLiteral};
 use lazy_static::lazy_static;

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crypto-literal-macro"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["kgv <kgv@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 description = "Crypto literal procedural macros macro."
@@ -15,7 +15,7 @@ proc-macro = true
 [dependencies]
 anyhow = "1.0.27"
 bincode = "1.2.1"
-crypto-literal-algorithm = "0.1.1"
+crypto-literal-algorithm = { path = "../algorithm/" }
 generic-array = "0.12.3"
 lazy_static = "1.4.0"
 proc-macro2 = "1.0.9"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@
 //! Basic usage:
 //!
 //! ```
-//! # #![feature(proc_macro_hygiene)]
-//! #
 //! # use crypto_literal::encrypt;
 //! #
 //! let crypto_literal = encrypt!("The quick brown fox jumps over the lazy dog");
@@ -15,8 +13,6 @@
 //! Static usage:
 //!
 //! ```
-//! # #![feature(proc_macro_hygiene)]
-//! #
 //! # use crypto_literal::{encrypt, CryptoLiteral};
 //! # use lazy_static::lazy_static;
 //! #

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 use anyhow::Result;
 use crypto_literal::{algorithm::Xor, Algorithm, CryptoLiteral};
 


### PR DESCRIPTION
Hi. `aes` version 0.3.2 has been yanked, so this crate couldn't build any more.I update the version of `aes` and `ofb` to the latest vesion and clean some code.This crate now should be build after rust 1.45 in stable channel.